### PR TITLE
Carefully unset proxy in apt

### DIFF
--- a/zetproxy
+++ b/zetproxy
@@ -58,7 +58,7 @@ proxy_apt()
 	if [ $WIFI_PROXY = "None" ]
 	then
 		echo '  -> Clearing apt proxy everywhere ...'
-        printf "Acquire::http::Proxy \"false\";" > ./.temp_file_apt;
+        printf "" > ./.temp_file_apt;
     else
 		printf "Acquire::http::Proxy \"$hp_pr\";\nAcquire::https::Proxy \"$hsp_pr\";\nAcquire::ftp::Proxy \"$fp_pr\";\n" > ./.temp_file_apt;
 		#echo Created apt.conf file


### PR DESCRIPTION
Fixes #42

Completely remove `Acquire::http::Proxy` instead of setting it to `false` because it causes problem for other programs.